### PR TITLE
FBCM-4353 Allow DQUOTEs in Cookie values

### DIFF
--- a/src/Biscotti/Cookie/Parser.purs
+++ b/src/Biscotti/Cookie/Parser.purs
@@ -26,8 +26,8 @@ import Data.Int as Int
 import Data.List (List)
 import Data.Maybe (Maybe(..))
 import Data.String as String
-import Text.Parsing.StringParser (ParseError, Parser, fail, runParser)
-import Text.Parsing.StringParser.CodePoints (eof, noneOf, string)
+import Text.Parsing.StringParser (ParseError, Parser, fail, runParser, try)
+import Text.Parsing.StringParser.CodePoints (char, eof, noneOf, string)
 import Text.Parsing.StringParser.Combinators (many, sepBy)
 
 type Attribute
@@ -100,8 +100,15 @@ parseAttribute =
 parseSimpleCookie :: Parser Cookie
 parseSimpleCookie = do
   name <- stringWithout ([ ';', ',', '=' ] <> whitespaceChars) <* string "="
-  value <- stringWithout ([ ';', ',' ] <> whitespaceChars)
+  value <- try stringLiteral <|> stringWithout ([ ';', ',' ] <> whitespaceChars)
   pure $ Cookie.new name value
+  where
+  stringLiteral :: Parser String
+  stringLiteral = do
+    _ <- char '"'
+    x <- stringWithout ['"']
+    _ <- char '"'
+    pure ("\"" <> x <> "\"")
 
 parseCookie :: Parser Cookie
 parseCookie = do

--- a/test/Test/Biscotti/CookieTest.purs
+++ b/test/Test/Biscotti/CookieTest.purs
@@ -107,7 +107,7 @@ testSuite = do
         Cookie.parse "key=val" `shouldEqual` Right expected
 
     suite "parseMany" do
-      test "parse value wrapped in DQUOTEs" do
+      test "parse value wrapped in double-quotes" do
         let
           expected =
             List.fromFoldable

--- a/test/Test/Biscotti/CookieTest.purs
+++ b/test/Test/Biscotti/CookieTest.purs
@@ -107,6 +107,35 @@ testSuite = do
         Cookie.parse "key=val" `shouldEqual` Right expected
 
     suite "parseMany" do
+      test "parse value wrapped in DQUOTEs" do
+        let
+          expected =
+            List.fromFoldable
+            [ Cookie.fromFields
+              { name: "key1"
+              , value: "val1"
+              , domain: Nothing
+              , path: Nothing
+              , expires: Nothing
+              , maxAge: Nothing
+              , sameSite: Nothing
+              , secure: false
+              , httpOnly: false
+              }
+            , Cookie.fromFields
+              { name: "key2"
+              , value: "\"Token 123\""
+              , domain: Nothing
+              , path: Nothing
+              , expires: Nothing
+              , maxAge: Nothing
+              , sameSite: Nothing
+              , secure: false
+              , httpOnly: false
+              }
+            ]
+
+        Cookie.parseMany "key1=val1; key2=\"Token 123\"" `shouldEqual` Right expected
       test "parses multiple name/value pairs only" do
         let
           expected =


### PR DESCRIPTION
## What does this pull request do?

Before this PR, white space is not allowed in cookie value which is why we've encountered an error when parsing a key whose value is wrapped in double quotes with a white space in it. This PR add the ability to parse cookie value with double quotes like `key="Token 123"`.